### PR TITLE
bug/stop monitor

### DIFF
--- a/internal/assets/views/js/game.js
+++ b/internal/assets/views/js/game.js
@@ -69,6 +69,7 @@ export let keys = {
 }, score = 0, lives = 3, level = 1, game = { over: false, active: false }, frames = 0;
 export let animationId;
 export let gameStartedTimestamp;
+let currentMonitorId = null;
 
 // Global frames counter for game entities
 window.frames = 0;
@@ -121,8 +122,9 @@ function endGame() {
     game.active = false;
     switchMusic(false, game); // Switch to normal music, then pause
     backgroundMusic.pause();
-    stopMonitor();
+    stopMonitor(currentMonitorId);
     stopMonitorStatusPolling();
+    currentMonitorId = null;
     
     // --- Highscore submission ---
     const timeTaken = Date.now() - gameStartedTimestamp;
@@ -150,8 +152,9 @@ function winGame() {
     game.active = false;
     switchMusic(false, game); // Switch to normal music, then pause
     backgroundMusic.pause();
-    stopMonitor();
+    stopMonitor(currentMonitorId);
     stopMonitorStatusPolling();
+    currentMonitorId = null;
     
     // --- Highscore submission ---
     const timeTaken = Date.now() - gameStartedTimestamp;
@@ -447,6 +450,14 @@ export async function startGame(countdownText, monitorUrl = '') {
         cancelAnimationFrame(animationId);
         animationId = null;
     }
+    
+    // Stop any existing monitor before starting a new one
+    if (currentMonitorId) {
+        stopMonitor(currentMonitorId);
+        stopMonitorStatusPolling();
+        currentMonitorId = null;
+    }
+    
     await init();
     gameStartedTimestamp = Date.now();
 
@@ -456,6 +467,7 @@ export async function startGame(countdownText, monitorUrl = '') {
             const { startMonitor, startMonitorStatusPolling } = await import('./api.js');
             const monitorId = await startMonitor(monitorUrl);
             if (monitorId) {
+                currentMonitorId = monitorId;
                 startMonitorStatusPolling(monitorId);
             }
         } catch (e) {


### PR DESCRIPTION
This pull request introduces changes to improve the handling of monitor lifecycle management in the `game.js` file. The changes ensure that monitors are properly stopped and cleaned up when a game ends, is won, or restarted. Key updates include the introduction of a `currentMonitorId` variable and modifications to relevant functions to use this variable for better monitor tracking.

### Monitor lifecycle management improvements:

* **Added `currentMonitorId` variable**: Introduced a new variable `currentMonitorId` to track the active monitor ID throughout the game lifecycle. (`[internal/assets/views/js/game.jsR72](diffhunk://#diff-e9cdaaef1ef44ec3b32bad4cf8fc1ed40307e095385f5f729e2c82049e127f1bR72)`)
* **Updated `endGame` and `winGame` functions**: Modified these functions to stop the monitor using `currentMonitorId` and reset it to `null` after stopping. (`[[1]](diffhunk://#diff-e9cdaaef1ef44ec3b32bad4cf8fc1ed40307e095385f5f729e2c82049e127f1bL124-R127)`, `[[2]](diffhunk://#diff-e9cdaaef1ef44ec3b32bad4cf8fc1ed40307e095385f5f729e2c82049e127f1bL153-R157)`)
* **Enhanced `startGame` function**:
  - Ensures any existing monitor is stopped before starting a new one by checking and stopping the `currentMonitorId`. (`[internal/assets/views/js/game.jsR453-R460](diffhunk://#diff-e9cdaaef1ef44ec3b32bad4cf8fc1ed40307e095385f5f729e2c82049e127f1bR453-R460)`)
  - Sets `currentMonitorId` to the newly created monitor ID after starting a new monitor. (`[internal/assets/views/js/game.jsR470](diffhunk://#diff-e9cdaaef1ef44ec3b32bad4cf8fc1ed40307e095385f5f729e2c82049e127f1bR470)`)- **Make highscore an interface, Add tests**
- **Fix an issue with stopping the monitor**
