### PR TITLE
Add support for running in openshift, using oauthproxy

### DIFF
--- a/deploy/pod-invaders/README-openshift.md
+++ b/deploy/pod-invaders/README-openshift.md
@@ -1,0 +1,155 @@
+# OpenShift Deployment with OAuth Proxy
+
+This document describes how to deploy Pod Invaders on OpenShift with OAuth authentication using the oauth-proxy sidecar.
+
+## Features
+
+- OpenShift OAuth integration for authentication
+- Automatic SSL/TLS termination with reencryption
+- Access token forwarding via `X-Forwarded-Access-Token` header
+- Service account token-based authentication
+- Automatic route creation
+
+## Prerequisites
+
+- OpenShift cluster with admin privileges
+- Helm 3.x installed
+- kubectl/oc CLI configured
+
+## Quick Start
+
+1. Deploy with OpenShift support enabled:
+
+```bash
+helm install pod-invaders ./pod-invaders -f values-openshift.yaml
+```
+
+1. Get the route URL:
+
+```bash
+oc get route pod-invaders -o jsonpath='{.spec.host}'
+```
+
+1. Access the application through the route URL. You'll be redirected to OpenShift OAuth for authentication.
+
+## Configuration
+
+### OpenShift OAuth Proxy
+
+The oauth-proxy sidecar is configured with the following key settings:
+
+- **Port**: 8443 (HTTPS)
+- **Provider**: OpenShift OAuth
+- **Authentication**: Service Account Token
+- **Access Token Forwarding**: Enabled via `X-Forwarded-Access-Token` header
+
+### Values Configuration
+
+Key configuration options in `values-openshift.yaml`:
+
+```yaml
+openshift:
+  enabled: true
+  oauthProxy:
+    port: 8443
+    extraArgs:
+      - "--pass-access-token"        # Forward access token to backend
+      - "--set-xauthrequest"        # Set X-Auth-Request headers
+      - "--pass-host-header"        # Pass original host header
+      - "--email-domain=*"          # Allow all email domains
+  route:
+    enabled: true
+    tls:
+      termination: "reencrypt"      # End-to-end encryption
+```
+
+## Backend Integration
+
+The pod-invaders Go server can access the user's access token through the `X-Forwarded-Access-Token` header:
+
+```go
+func (h *Handler) someHandler(w http.ResponseWriter, r *http.Request) {
+    accessToken := r.Header.Get("X-Forwarded-Access-Token")
+    if accessToken == "" {
+        http.Error(w, "Unauthorized", http.StatusUnauthorized)
+        return
+    }
+    
+    // Use the access token to make authenticated requests to the Kubernetes API
+    // This token can be used with the Kubernetes client-go library
+}
+```
+
+## Security Considerations
+
+1. **Service Account Permissions**: The service account is granted cluster-wide permissions to list and delete pods in configured namespaces.
+
+1. **TLS Encryption**:
+   - External traffic uses TLS termination at the route level
+   - Internal traffic between oauth-proxy and pod-invaders uses HTTP (localhost)
+   - Route is configured with `reencrypt` for end-to-end encryption
+
+1. **Token Security**: Access tokens are passed via headers and should be handled securely in the backend application.
+
+## Customization
+
+### Custom OAuth Configuration
+
+You can customize the OAuth proxy behavior by modifying the `extraArgs` in values:
+
+```yaml
+openshift:
+  oauthProxy:
+    extraArgs:
+      - "--skip-auth-regex=^/health"     # Skip auth for health checks
+      - "--pass-access-token"            # Forward access token
+      - "--cookie-expire=24h"            # Set cookie expiration
+      - "--cookie-refresh=1h"            # Set cookie refresh interval
+```
+
+### Custom Route Configuration
+
+```yaml
+openshift:
+  route:
+    host: "pod-invaders.apps.my-cluster.com"
+    annotations:
+      haproxy.router.openshift.io/timeout: "60s"
+```
+
+## Troubleshooting
+
+1. **Authentication Issues**:
+
+   ```bash
+   oc logs deployment/pod-invaders -c oauth-proxy
+   ```
+
+1. **Route Not Accessible**:
+
+   ```bash
+   oc get route pod-invaders
+   oc describe route pod-invaders
+   ```
+
+1. **Permission Issues**:
+
+   ```bash
+   oc get clusterrolebinding | grep pod-invaders
+   oc describe clusterrole pod-invaders
+   ```
+
+1. **Certificate Issues**:
+
+   ```bash
+   oc get secret pod-invaders-proxy-tls
+   oc describe secret pod-invaders-proxy-tls
+   ```
+
+## Uninstalling
+
+```bash
+helm uninstall pod-invaders
+```
+
+This will remove all resources including the route, secrets, and RBAC configurations.

--- a/deploy/pod-invaders/templates/NOTES.txt
+++ b/deploy/pod-invaders/templates/NOTES.txt
@@ -1,7 +1,11 @@
 🚀 Pod Invaders has been deployed successfully!
 
 1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
+{{- if and .Values.openshift.enabled .Values.openshift.route.enabled }}
+  export ROUTE_HOST=$(oc get route {{ include "pod-invaders.fullname" . }} -o jsonpath='{.spec.host}')
+  echo "🎮 Pod Invaders available at: https://$ROUTE_HOST"
+  echo "🔐 Authentication: OpenShift OAuth (login with your OpenShift credentials)"
+{{- else if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
@@ -18,13 +22,22 @@
   echo "🎮 Pod Invaders available at: http://$SERVICE_IP:{{ .Values.service.port }}"
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "pod-invaders.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  {{- if .Values.openshift.enabled }}
+  echo "🎮 Visit http://127.0.0.1:8443 to play Pod Invaders!"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8443:8443
+  {{- else }}
   echo "🎮 Visit http://127.0.0.1:3000 to play Pod Invaders!"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000:3000
+  {{- end }}
 {{- end }}
 
 📝 Configuration:
 - Kubernetes integration: {{ .Values.config.enableKube }}
 - Target namespaces: {{ join ", " .Values.config.namespaces }}
+{{- if .Values.openshift.enabled }}
+- OpenShift OAuth: Enabled (oauth-proxy sidecar deployed)
+- Access token forwarding: Enabled via X-Forwarded-Access-Token header
+{{- end }}
 {{- if .Values.rbac.create }}
 - RBAC: Enabled (ClusterRole created for pod management)
 {{- else }}

--- a/deploy/pod-invaders/templates/deployment.yaml
+++ b/deploy/pod-invaders/templates/deployment.yaml
@@ -33,6 +33,39 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
+        {{- if .Values.openshift.enabled }}
+        - name: oauth-proxy
+          image: "{{ .Values.openshift.oauthProxy.image.repository }}:{{ .Values.openshift.oauthProxy.image.tag }}"
+          imagePullPolicy: {{ .Values.openshift.oauthProxy.image.pullPolicy }}
+          ports:
+            - name: oauth-proxy
+              containerPort: {{ .Values.openshift.oauthProxy.port }}
+              protocol: TCP
+          args:
+            - "--https-address=:{{ .Values.openshift.oauthProxy.port }}"
+            - "--provider=openshift"
+            - "--openshift-service-account={{ include "pod-invaders.serviceAccountName" . }}"
+            - "--upstream={{ .Values.openshift.oauthProxy.upstreamUrl }}"
+            - "--tls-cert=/etc/tls/private/tls.crt"
+            - "--tls-key=/etc/tls/private/tls.key"
+            - "--client-id={{ .Values.openshift.oauthProxy.clientId }}"
+            - "--client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token"
+            - "--cookie-secret-file=/etc/proxy/secrets/session_secret"
+            {{- range .Values.openshift.oauthProxy.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- with .Values.openshift.oauthProxy.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: proxy-tls
+              mountPath: /etc/tls/private
+              readOnly: true
+            - name: proxy-secrets
+              mountPath: /etc/proxy/secrets
+              readOnly: true
+        {{- end }}
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}
           securityContext:
@@ -70,10 +103,18 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.volumes }}
       volumes:
+        {{- if .Values.openshift.enabled }}
+        - name: proxy-tls
+          secret:
+            secretName: {{ include "pod-invaders.fullname" . }}-proxy-tls
+        - name: proxy-secrets
+          secret:
+            secretName: {{ include "pod-invaders.fullname" . }}-proxy-secrets
+        {{- end }}
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/pod-invaders/templates/route.yaml
+++ b/deploy/pod-invaders/templates/route.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.openshift.enabled .Values.openshift.route.enabled -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "pod-invaders.fullname" . }}
+  labels:
+    {{- include "pod-invaders.labels" . | nindent 4 }}
+  {{- with .Values.openshift.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.openshift.route.host }}
+  host: {{ .Values.openshift.route.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "pod-invaders.fullname" . }}
+    weight: 100
+  port:
+    targetPort: oauth-proxy
+  {{- with .Values.openshift.route.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/deploy/pod-invaders/templates/secrets.yaml
+++ b/deploy/pod-invaders/templates/secrets.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.openshift.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pod-invaders.fullname" . }}-proxy-secrets
+  labels:
+    {{- include "pod-invaders.labels" . | nindent 4 }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ include "pod-invaders.fullname" . }}-proxy-tls
+type: Opaque
+data:
+  {{- if .Values.openshift.oauthProxy.cookieSecret }}
+  session_secret: {{ .Values.openshift.oauthProxy.cookieSecret | b64enc }}
+  {{- else }}
+  session_secret: {{ randAlphaNum 32 | b64enc }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pod-invaders.fullname" . }}-proxy-tls
+  labels:
+    {{- include "pod-invaders.labels" . | nindent 4 }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ include "pod-invaders.fullname" . }}-proxy-tls
+type: kubernetes.io/tls
+{{- end }}

--- a/deploy/pod-invaders/templates/service.yaml
+++ b/deploy/pod-invaders/templates/service.yaml
@@ -7,6 +7,12 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
+    {{- if .Values.openshift.enabled }}
+    - port: {{ .Values.openshift.oauthProxy.port }}
+      targetPort: oauth-proxy
+      protocol: TCP
+      name: oauth-proxy
+    {{- end }}
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP

--- a/deploy/pod-invaders/templates/serviceaccount.yaml
+++ b/deploy/pod-invaders/templates/serviceaccount.yaml
@@ -5,9 +5,12 @@ metadata:
   name: {{ include "pod-invaders.serviceAccountName" . }}
   labels:
     {{- include "pod-invaders.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
   annotations:
+    {{- if .Values.openshift.enabled }}
+    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiGroup":"v1","name":"{{ include "pod-invaders.fullname" . }}","namespace":"{{ .Release.Namespace }}"}'
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}

--- a/deploy/pod-invaders/values-openshift.yaml
+++ b/deploy/pod-invaders/values-openshift.yaml
@@ -1,3 +1,4 @@
+# Example values.yaml for OpenShift deployment with oauth-proxy
 replicaCount: 1
 
 image:
@@ -58,7 +59,7 @@ readinessProbe:
 
 # OpenShift specific configuration
 openshift:
-  enabled: false
+  enabled: true
   oauthProxy:
     image:
       repository: quay.io/openshift/origin-oauth-proxy
@@ -74,8 +75,8 @@ openshift:
         memory: 32Mi
     # OAuth proxy configuration
     clientId: "pod-invaders"
-    clientSecret: ""  # Should be provided via secret
-    cookieSecret: ""  # Should be provided via secret, base64 encoded 32-byte value
+    clientSecret: ""  # Will use service account token
+    cookieSecret: ""  # Will be auto-generated if not provided
     upstreamUrl: "http://localhost:3000"
     # Additional oauth-proxy arguments
     extraArgs:
@@ -108,5 +109,3 @@ ingress:
         - path: /
           pathType: Prefix
   tls: []
-
-

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"log"
+
+	"github.com/gofiber/fiber/v2"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// OpenShiftAuthMiddleware extracts the user's access token from the oauth-proxy
+func (s *Server) OpenShiftAuthMiddleware() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		// Skip authentication for health checks
+		if c.Path() == "/healthz" || c.Path() == "/readyz" {
+			return c.Next()
+		}
+
+		// Extract the access token from the header set by oauth-proxy
+		accessToken := c.Get("X-Forwarded-Access-Token")
+		if accessToken == "" {
+			log.Printf("No access token found in request")
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "Authentication required",
+			})
+		}
+
+		// Create a Kubernetes client using the user's token
+		config := &rest.Config{
+			Host:        s.kubeConfig.Host,
+			BearerToken: accessToken,
+			TLSClientConfig: rest.TLSClientConfig{
+				CAData: s.kubeConfig.CAData,
+			},
+		}
+
+		clientset, err := kubernetes.NewForConfig(config)
+		if err != nil {
+			log.Printf("Failed to create Kubernetes client with user token: %v", err)
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+				"error": "Invalid authentication token",
+			})
+		}
+
+		// Store the authenticated client in the context for use by handlers
+		c.Locals("kubeClient", clientset)
+		c.Locals("userToken", accessToken)
+
+		return c.Next()
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,10 +10,11 @@ import (
 
 // Config holds the application configuration.
 type Config struct {
-	Kubeconfig      string
-	EnableKube      bool
-	NamespaceNames  []string
-	HighscoreDBPath string // Path to the highscore database
+	Kubeconfig          string
+	EnableKube          bool
+	NamespaceNames      []string
+	HighscoreDBPath     string // Path to the highscore database
+	EnableOpenShiftAuth bool   // Enable OpenShift OAuth authentication
 }
 
 // New initializes a new Config object from command-line flags.
@@ -25,6 +26,8 @@ func New() *Config {
 	pflag.BoolVar(&cfg.EnableKube, "enable-kube", true, "Enable Kubernetes client (default: true)")
 	pflag.StringArrayVar(&cfg.NamespaceNames, "namespaces", []string{"default"}, "List of namespaces to query pods from (default: default)")
 	pflag.StringVar(&cfg.HighscoreDBPath, "highscore-db", "/tmp/highscores.db", "Path to the highscore database file")
+	// EnableOpenShiftAuth
+	pflag.BoolVar(&cfg.EnableOpenShiftAuth, "enable-openshift-auth", false, "Enable OpenShift OAuth authentication (default: false)")
 
 	// Add Go's standard flags to pflag
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)


### PR DESCRIPTION
This pull request introduces OpenShift-specific features to the Pod Invaders deployment, including OAuth authentication, route creation, and configuration updates. The changes add support for deploying the application on OpenShift clusters with enhanced security and integration. Below are the most important changes grouped by theme:

### OpenShift Deployment and OAuth Integration:
* Added a new `README-openshift.md` file documenting the OpenShift deployment process, including OAuth proxy configuration, route creation, and security considerations (`deploy/pod-invaders/README-openshift.md`, [deploy/pod-invaders/README-openshift.mdR1-R155](diffhunk://#diff-66e2bb967b4af2161ff8c515f6dde42f0795214aced08701a487f73adc1919a6R1-R155)).
* Introduced OpenShift-specific configuration in `values-openshift.yaml`, enabling OAuth proxy, route settings, and resource limits (`deploy/pod-invaders/values-openshift.yaml`, [deploy/pod-invaders/values-openshift.yamlR1-R111](diffhunk://#diff-ba0bd275f36e00bf65d072222196fed11ef5a80e7969c26b8503c233fd07013eR1-R111)).
* Updated the Helm chart to include an OAuth proxy container, route definitions, and secrets for TLS and session management (`deploy/pod-invaders/templates/deployment.yaml`, [[1]](diffhunk://#diff-2e9dceae2014b445836992265c4eeeb00339c50ac44891cf53055f98c8ac3055R36-R68) [[2]](diffhunk://#diff-2e9dceae2014b445836992265c4eeeb00339c50ac44891cf53055f98c8ac3055L73-R115); `deploy/pod-invaders/templates/route.yaml`, [[3]](diffhunk://#diff-62a136477791c821e786af0bf2cf2f222d9d402554b50274e3656bc2bd915a42R1-R27); `deploy/pod-invaders/templates/secrets.yaml`, [[4]](diffhunk://#diff-172cd38c8bda48870b4c8d7251117248b89dce4aafa1052361dc545d2a052b1bR1-R27).

### Application Code Changes for OpenShift Support:
* Added middleware to handle OpenShift OAuth authentication, extracting access tokens and creating Kubernetes clients dynamically (`internal/api/middleware.go`, [internal/api/middleware.goR1-R51](diffhunk://#diff-97dfc3310e5139b4d9c7a160bd077aeb81ca1e7b8d7cfa837a402f54b4c03a3dR1-R51)).
* Updated API handlers to use the authenticated Kubernetes client when OpenShift OAuth is enabled (`internal/api/handlers.go`, [[1]](diffhunk://#diff-6c6fe69fba99e4fd8a5b14a2751c6ef8363e4054217bbaab768340dedfb72735R58-R66) [[2]](diffhunk://#diff-6c6fe69fba99e4fd8a5b14a2751c6ef8363e4054217bbaab768340dedfb72735R91-R98).
* Enhanced the server configuration to support OpenShift OAuth and integrated it into the application lifecycle (`internal/api/server.go`, [[1]](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093R15) [[2]](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093R32) [[3]](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093R42-R47) [[4]](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093R83-R85); `internal/config/config.go`, [[5]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR17).

### Helm Chart Updates:
* Modified `NOTES.txt` to provide OpenShift-specific instructions for accessing the application and using port-forwarding (`deploy/pod-invaders/templates/NOTES.txt`, [[1]](diffhunk://#diff-de55c56d6835ca08627c79db087bfed4d53c27f5d15f0fb6b65319a7c25ec6f0L4-R8) [[2]](diffhunk://#diff-de55c56d6835ca08627c79db087bfed4d53c27f5d15f0fb6b65319a7c25ec6f0R25-R40).
* Updated `service.yaml` to include a port for the OAuth proxy when OpenShift is enabled (`deploy/pod-invaders/templates/service.yaml`, [deploy/pod-invaders/templates/service.yamlR10-R15](diffhunk://#diff-5cdb6f2aec370ed6016146ec34f5701854b0c07c173ab520b0694810f99c2cfcR10-R15)).
* Added annotations to `serviceaccount.yaml` for OpenShift OAuth redirect reference (`deploy/pod-invaders/templates/serviceaccount.yaml`, [deploy/pod-invaders/templates/serviceaccount.yamlL8-R12](diffhunk://#diff-147cd0391c994469e1bdcb405200fdea1b1f70cf5503176f2462975003e472dcL8-R12)).

### Default Configuration Changes:
* Introduced OpenShift-specific settings in the default `values.yaml` file, including OAuth proxy and route configuration (`deploy/pod-invaders/values.yaml`, [deploy/pod-invaders/values.yamlR59-R111](diffhunk://#diff-694b5cb7fcb037f80dbe2c25388f8e4acd4186030635260fe94495685cedf0f9R59-R111)).

These changes collectively enable seamless deployment of Pod Invaders on OpenShift with enhanced authentication and security features.